### PR TITLE
Monitor each DATABASE_URL

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -8,14 +8,18 @@ token = ENV['LIBRATO_TOKEN']
 raise 'missing LIBRATO_USER'  unless user
 raise 'missing LIBRATO_TOKEN' unless token
 
+COLLECTION_INTERVAL = 5
 Librato::Metrics.authenticate user, token
 
 include Clockwork
 counters = {}
-every 5.minutes, 'postgres_performance' do
-  uri = URI.parse(ENV["DATABASE_URL"])
-  database_name = uri.path[1..-1]
-  Sequel.connect(uri.to_s) do |db|
-    PGStats.new(db: db, interval: 60 * 5, counters: counters, source: database_name).submit
+every COLLECTION_INTERVAL.minutes, 'postgres_performance' do
+  database_urls = ENV.keys.select{|k| k =~ /DATABASE_URL/}.map{|k| ENV[k]}
+  uris = database_urls.map{|url| URI.parse(url) }
+  uris.each do |uri|
+    database_name = uri.path[1..-1]
+    Sequel.connect(uri.to_s) do |db|
+      PGStats.new(db: db, interval: 60 * COLLECTION_INTERVAL, counters: counters, source: database_name).submit
+    end
   end
 end


### PR DESCRIPTION
- https://thinkneardev.atlassian.net/browse/IRIS-376
# 

The monitor will pull stats for each database url matching /DATABASE_URL/. So it makes it possible to set multiple databases to monitor on the Heroku configs. For example DATABASE_URL_APP1 and DATABASE_URL_APP2.
